### PR TITLE
patches: added Vanguard Saga of Heroes fix

### DIFF
--- a/patches/game-patches/vgsoh.patch
+++ b/patches/game-patches/vgsoh.patch
@@ -1,0 +1,19 @@
+diff --git a/dlls/kernelbase/file.c b/dlls/kernelbase/file.c
+index f4f9d14518f..4bfcfec02fb 100644
+--- a/dlls/kernelbase/file.c
++++ b/dlls/kernelbase/file.c
+@@ -2917,6 +2917,14 @@ BOOL WINAPI DECLSPEC_HOTPATCH SetCurrentDirectoryA( LPCSTR dir )
+ BOOL WINAPI DECLSPEC_HOTPATCH SetCurrentDirectoryW( LPCWSTR dir )
+ {
+     UNICODE_STRING dirW;
++    SIZE_T len = wcslen(dir);
++
++    if (len > 0 && dir[len - 1] == '.')
++    {
++        WCHAR *p = (WCHAR *)dir + len - 1;
++        *p = '\0';
++        FIXME("%s . fixed\n", debugstr_w(dir));
++    }
+ 
+     RtlInitUnicodeString( &dirW, dir );
+     return set_ntstatus( RtlSetCurrentDirectory_U( &dirW ));

--- a/patches/protonprep-valve-staging.sh
+++ b/patches/protonprep-valve-staging.sh
@@ -297,6 +297,9 @@
     echo "WINE: -GAME FIXES- add xinput support to Dragon Age Inquisition"
     patch -Np1 < ../patches/game-patches/dai_xinput.patch
 
+    echo "WINE: -GAME FIXES- add set current directory workaround for Vanguard Saga of Heroes"
+    patch -Np1 < ../patches/game-patches/vgsoh.patch
+
     echo "WINE: -GAME FIXES- add __TRY/__EXCEPT_PAGE_FAULT wnsprintfA xDefiant patch because of a bad arg passed by the game that would exit to desktop"
     patch -Np1 < ../patches/game-patches/xdefiant.patch
 


### PR DESCRIPTION
Context:
Vanguard Saga of Heroes is an MMORPG that was closed years ago by SOE. 
The game is still alive in the emulator scene at https://vgoemulator.net/

The game seem to have relied on an old behaviour of the function `SetCurrentDirectoryW( LPCWSTR dir )`
which currently crashes the game.

This patch was solution was discovered by the community at https://vgoemulator.net/phpBB3/viewtopic.php?t=5563

Summary of changes:

- Updates the function `SetCurrentDirectoryW( LPCWSTR dir )` through a patch that removes the trailing ".".
- Previously the game will try to access "bin\.Caches" and crash. It will now access "bin\Caches" and run successfully


Notes:

- This is my attempt to get this change upstream so the community does not have to rely on a custom build of Proton-GE and can get the benefits of it being upstream
- I am new to the wine ecosystem so please do let me know if there is a better way to get this upstream